### PR TITLE
Enrich main pages with vitality language and ICP framing

### DIFF
--- a/AGENT_BOOT.md
+++ b/AGENT_BOOT.md
@@ -1,5 +1,7 @@
 # Commons OS Pattern Library - Agent Boot Procedure
 
+**Mission:** Our mission is to empower Commons Engineers by tending this living library of patterns.
+
 > **READ THIS FIRST** when starting a new session to load context and avoid repeating past mistakes.
 
 ## Quick Stats (Updated: 2026-02-02)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,200 +1,60 @@
-'''
-# Commons OS Pattern Engine: Architecture
+# Architecture of a Living Library
 
-**Version**: 1.0
-**Date**: 2026-02-01
-**Author**: Manus AI
-
-## 1. Vision & Guiding Principles
-
-The Commons OS Pattern Engine is not a static library; it is a **living knowledge system** designed to capture, connect, and continuously improve a scalable graph of patterns and their real-world implementations (Lighthouses). Its purpose is to serve as the canonical, queryable, and machine-readable foundation for Commons Engineers—both human and AI.
-
-### Guiding Principles
-
-| Principle | Description |
-|---|---|
-| **Scalability** | The architecture must support tens of thousands of entities (Patterns, Lighthouses) without performance degradation. |
-| **Durability** | Entities and their relationships must be durable over time, with stable identifiers and version history. |
-| **Extensibility** | The schema must be easily extendable to accommodate new entity types, relationships, and metadata. |
-| **Quality by Design** | The system must have built-in gates and workflows that ensure a high standard of quality, consistency, and completeness. |
-| **Intelligence & Automation** | The system will leverage AI to automate enrichment, discover relationships, and maintain the health of the knowledge graph. |
-| **Human in the Loop** | While highly automated, the system requires human oversight for final approval, ensuring contextual relevance and wisdom are applied. |
+**Date:** 17 February 2026
+**Authors:** higgerix, cloudsters
+**Status:** v2.0
 
 ---
 
-## 2. Core Architecture
+This document outlines the architecture of the Commons OS Pattern Library. Its purpose is not to be a static blueprint, but a living guide for how we cultivate this shared knowledge garden.
 
-The architecture is based on a staged, gated workflow that moves entities from creation to a canonical, published state. This ensures that no entity enters the main knowledge graph without passing validation and enrichment.
+## 1. Vision: A Living Knowledge System
+
+Our goal is to create a system that feels alive—one that learns, adapts, and evolves alongside the community it serves. We are not building a database of text files; we are tending a knowledge graph that helps **Cognitive Systems Builders** see the connections between problems, solutions, and each other.
+
+This architecture is designed to support that vision through three core principles:
+
+1.  **Write Once, Render Richly:** Separate authoring from presentation to keep the writing process clean and the user experience rich.
+2.  **Machine-Readable by Default:** Structure all data in YAML frontmatter to make the graph computable, searchable, and extensible.
+3.  **Community-Tended:** The system is designed to be forked, extended, and improved by the community it serves.
+
+## 2. Core Components
+
+-   **Jekyll:** The static site generator that transforms our Markdown files into a website.
+-   **GitHub Pages:** Hosts the live site directly from the repository.
+-   **YAML Frontmatter:** The structured data heart of every pattern.
+-   **Markdown Body:** The narrative soul of every pattern.
+-   **Liquid:** The templating language used by Jekyll to weave the data and narrative together.
+
+## 3. The Pattern Lifecycle Engine
+
+The true "aliveness" of the system comes from the Pattern Engine Lifecycle, which ensures that our collective knowledge is constantly tested, adapted, and renewed.
 
 ```mermaid
 graph TD
-    subgraph "Local Environment / Contributor"
-        A[1. Create/Edit Pattern in _staging/]
-    end
-
-    subgraph "GitHub: Pull Request"
-        B[2. PR to main branch]
-        C{3. Quality Gate}
-        D[4. Enrichment Gate]
-    end
-
-    subgraph "GitHub: Main Branch"
-        E[5. Human Review & Merge]
-        F[6. Promotion to _patterns/]
-        G[7. Graph Update]
-    end
-
-    subgraph "Scheduled Maintenance"
-        H((8. Health Checks))
-    end
-
-    A --> B
-    B --> C
-    C -- Validation Pass --> D
-    C -- Validation Fail --> B
-    D -- Enrichment Report --> E
-    E --> F
-    F --> G
-    G --> H
-    H --> G
+    A[Recognition] --> B[Application]
+    B --> C{Context Shift?}
+    C -- No --> B
+    C -- Yes --> D[Adaptation]
+    D --> B
+    D --> E[Creation]
+    E --> B
 ```
 
-### Components
+-   **Recognition:** Identifying that a recurring problem has a known solution.
+-   **Application:** Deploying a proven pattern to a known problem.
+-   **Adaptation:** Modifying a pattern when the context shifts.
+-   **Creation:** Authoring a new pattern when no existing solution fits.
 
-| Component | Description | Implementation |
-|---|---|---|
-| **Staging Area (`_staging/`)** | A dedicated directory where new or modified patterns reside before being promoted. | Git directory |
-| **Quality Gate** | An automated workflow that validates the format, schema, and basic completeness of a pattern. | GitHub Action (`validate-patterns.yml`) |
-| **Enrichment Gate** | An AI-powered workflow that suggests tags, discovers relationships, and scores content quality. | GitHub Action (`enrich-pattern.yml`) |
-| **Promotion Workflow** | A manual or semi-automated process to move a validated and enriched pattern from `_staging/` to `_patterns/`. | GitHub Action (`promote-pattern.yml`) |
-| **Knowledge Graph** | A structured representation of all entities and their relationships. | JSON files (`graph.json`), scalable to a graph database (e.g., Neo4j). |
-| **Maintenance Jobs** | Scheduled tasks that check for broken links, suggest new relationships, and monitor the overall health of the graph. | GitHub Actions (cron jobs) |
+This lifecycle is not a linear process, but a continuous loop of sensing, responding, and learning.
 
----
+## 4. Workflow & Validation
 
-## 3. Entity & Relationship Model
+Our authoring workflow is designed to be simple for humans and rigorous for machines.
 
-The system is built on two primary entity types: **Patterns** and **Lighthouses**.
-
-### Entity Schema
-
-Both entities share a common base schema and have specific fields.
-
-**Base Schema:**
-- `id`: Globally unique, immutable TypeID (`pat_...` or `lh_...`).
-- `slug`: Human-readable, URL-friendly identifier.
-- `title`: The official name of the entity.
-- `version`: Semantic version (e.g., 1.0, 1.1).
-- `status`: The current state in the quality lifecycle (`draft`, `review`, `published`, `mature`, `deprecated`).
-- `created`, `modified`: ISO 8601 timestamps.
-- `tags`: A flexible key-value store for metadata.
-
-**Pattern-Specific Schema:**
-- `tags.commons_alignment`: A 1-5 score.
-- `tags.domain`: `governance`, `security`, `startup`, etc.
-- `content`: The full Markdown body of the pattern.
-
-**Lighthouse-Specific Schema:**
-- `tags.industry`: `technology`, `agriculture`, `finance`, etc.
-- `location`: Geographic location.
-- `summary`: A brief description of the organization or project.
-
-### Relationship Schema
-
-Relationships are the core of the knowledge graph, stored with directionality.
-
-| Relationship | Source -> Target | Description |
-|---|---|---|
-| `generalizes_from` | Pattern -> Pattern | "Steward Ownership" is a more general form of "Perpetual Purpose Trust". |
-| `specializes_to` | Pattern -> Pattern | "Perpetual Purpose Trust" is a specialization of "Steward Ownership". |
-| `enables` | Pattern -> Pattern | "Zero Trust Architecture" enables "Secure Remote Access". |
-| `requires` | Pattern -> Pattern | "Secure Remote Access" requires "Zero Trust Architecture". |
-| `related` | Pattern <-> Pattern | "Sociocracy" is related to "Holacracy". |
-| `implements` | Lighthouse -> Pattern | "Patagonia" implements the "Steward Ownership" pattern. |
-| `applied_by` | Pattern -> Lighthouse | "Steward Ownership" is applied by "Patagonia". |
-| `inspired_by` | Lighthouse -> Lighthouse | "Company B" was inspired by "Company A". |
-| `collaborates_with` | Lighthouse <-> Lighthouse | "Lighthouse X" collaborates with "Lighthouse Y". |
-
----
-
-## 4. Quality Lifecycle
-
-Every entity progresses through a defined lifecycle to ensure quality and relevance.
-
-```mermaid
-stateDiagram-v2
-    [*] --> draft
-    draft --> review: Submit for Review
-    review --> draft: Revisions Requested
-    review --> published: Approved
-    published --> mature: Becomes Widely Adopted
-    published --> deprecated: Becomes Obsolete
-    mature --> deprecated: Becomes Obsolete
-    deprecated --> [*]
-```
-
-| State | Description |
-|---|---|
-| `draft` | Initial creation in `_staging/`. Not yet validated. |
-| `review` | Submitted for review. Undergoing automated and human checks. |
-| `published` | Validated, enriched, and promoted to `_patterns/`. Part of the canonical set. |
-| `mature` | A published pattern that is highly connected and widely referenced. |
-| `deprecated` | Outdated or superseded. Kept for historical context but flagged as no longer best practice. |
-
----
-
-## 5. Tooling & Implementation
-
-The system will be implemented using a combination of Python scripts and GitHub Actions.
-
-### Core Scripts (`scripts/`)
-
-| Script | Description |
-|---|---|
-| `generate_typeid.py` | Generates unique, stable IDs for new entities. |
-| `validate_entity.py` | Validates a given entity file against the schema defined in `PATTERN_SPEC.md` and `LIGHTHOUSE_SPEC.md`. |
-| `enrich_entity.py` | The AI-powered orchestrator. It runs the quality checker, tag refiner, and relationship builder. |
-| `build_graph.py` | Traverses all canonical entities (`_patterns/`, `_lighthouses/`) and builds the `graph.json` file. |
-
-### AI-Powered Enrichment Modules (used by `enrich_entity.py`)
-
-| Module | Description |
-|---|---|
-| **Quality Checker** | Uses an LLM to score content for clarity, completeness, and justification of its 7 Pillars assessment. |
-| **Tag Refiner** | Analyzes content to suggest relevant tags (`domain`, `category`, etc.) based on a taxonomy. |
-| **Relationship Builder** | Uses embeddings (e.g., OpenAI `text-embedding-3-small`) to find semantically similar entities and suggest `related`, `enables`, etc. relationships. |
-
-### GitHub Actions (`.github/workflows/`)
-
-| Workflow | Trigger | Description |
-|---|---|---|
-| `validate.yml` | PR to `main` | **Quality Gate**. Runs `validate_entity.py` on all changed files in `_staging/`. Blocks merge on failure. |
-| `enrich.yml` | PR to `main` | **Enrichment Gate**. Runs `enrich_entity.py` and posts a summary report as a PR comment. |
-| `promote.yml` | Manual trigger | **Promotion**. Merges the PR and moves the validated files from `_staging/` to their canonical directories. |
-| `update-graph.yml` | Push to `main` | Runs `build_graph.py` to update the knowledge graph after a promotion. |
-| `health-check.yml` | Scheduled (weekly) | Runs maintenance tasks: checks for broken links, finds orphaned entities, suggests new relationships for mature patterns. |
-
----
-
-## 6. Next Steps & Implementation Plan
-
-1.  **Phase 1: Build Core Tooling**
-    - Implement `generate_typeid.py` and `validate_entity.py`.
-    - Create `PATTERN_SPEC.md` and `LIGHTHOUSE_SPEC.md`.
-    - Set up the `validate.yml` GitHub Action.
-
-2.  **Phase 2: Build Staging & Promotion Workflow**
-    - Establish the `_staging/` directory structure.
-    - Create the `promote.yml` GitHub Action.
-
-3.  **Phase 3: Build Enrichment Pipeline**
-    - Implement the AI-powered enrichment scripts (`enrich_entity.py` and its modules).
-    - Create the `enrich.yml` GitHub Action.
-
-4.  **Phase 4: Build Knowledge Graph & Maintenance**
-    - Implement `build_graph.py` and the `update-graph.yml` action.
-    - Create the `health-check.yml` scheduled job.
-
-5.  **Phase 5: Process Backlog**
-    - Use the complete system to process the Security and Startup patterns, moving them through the full lifecycle.
-'''
+1.  **Create File:** `cp _templates/pattern.md _patterns/{slug}.md`
+2.  **Author Content:** Fill in the YAML frontmatter and the 8 body sections, telling the story of the pattern.
+3.  **Submit PR:** Open a pull request to the `main` branch.
+4.  **Automated Validation:** A GitHub Action validates the file against the `PATTERN_SPEC.md`.
+5.  **Community Review:** Peers review the pattern for clarity, coherence, and vitality.
+6.  **Merge & Publish:** Once approved, the pattern is merged and becomes a living part of the commons.

--- a/PATTERN_SPEC.md
+++ b/PATTERN_SPEC.md
@@ -1,335 +1,223 @@
-# Pattern Engine Specification
+# Pattern Specification (v7.1)
 
-> **IMPORTANT**: This document is the authoritative source of truth for pattern format.
-> **ALL contributors (human and AI) MUST read this before creating or modifying patterns.**
-
-## Purpose
-
-This specification ensures consistency across all patterns in the Commons OS Pattern Library. It defines the exact format, required fields, and validation rules that every pattern must follow.
+**Date:** 17 February 2026
+**Authors:** higgerix, cloudsters
+**Status:** Definitive Specification (v7.1)
+**Supersedes:** v1.3 (02 February 2026)
 
 ---
 
-## 1. File Location & Naming
+## 1. Purpose: A Language for Stewards
 
-### Location
-All patterns MUST be stored in:
-```
-_patterns/
-```
+This specification defines the format for patterns in the Commons OS library. Its purpose is to provide a shared language for **Cognitive Systems Builders**—the intrapreneurs, entrepreneurs, and systems thinkers designing the resilient, living systems of the Cognitive Age.
 
-### Filename Format
-```
-{slug}.md
-```
-
-**Rules:**
-- `slug`: Lowercase, hyphen-separated, human-readable identifier
-- Extension: `.md` (Markdown)
-- Slug MUST be unique across all patterns
-- Slug SHOULD be descriptive enough to distinguish similar patterns
-
-**Examples:**
-```
-sociocracy-original-gerard-endenburg.md
-steward-ownership.md
-zero-trust-architecture.md
-privacy-by-design-cavoukian.md
-```
-
-**Slug Naming Guidelines:**
-- Use the pattern's common name as the base
-- Add originator name if multiple variants exist (e.g., `sociocracy-original-gerard-endenburg.md`)
-- Add distinguishing context if needed (e.g., `privacy-by-design-cavoukian.md` vs `privacy-by-design-gdpr.md`)
-
-**DO NOT USE:**
-- Sequential numbers (e.g., `1024-`, `1025-`)
-- Category prefixes (e.g., `P001-`, `S031-`, `IV001-`)
-- UUIDs in filenames
-- Uppercase letters
+Following this spec ensures that every pattern is not just a document, but a tool: a legible, repeatable, and machine-readable artifact that helps you make your systems thinking visible, influential, and effective.
 
 ---
 
-## 2. Pattern ID (TypeID)
+## 2. The Core Principle: Write Once, Render Richly
 
-Every pattern MUST have a unique `id` in TypeID format based on UUID7.
+The source of truth (the Markdown file) is optimized for the **author**, while the rendered web page is optimized for the **reader**. We achieve this by keeping the author-written body focused on the core narrative, and then programmatically injecting machine-readable data from the frontmatter into the page at build time.
 
-### Format
-```
-pat_{uuid7_base32}
-```
+-   **Author Focus:** Write the story (Context, Problem, Solution, etc.) in a clear, narrative flow that makes the reader feel the life of the system.
+-   **Machine Focus:** Structure all graph data, metadata, and relationships in the YAML frontmatter.
+-   **Build Process:** A build script reads the frontmatter and renders it as rich, human-readable components on the page (e.g., a visual score card for the Commons Alignment, a dynamic list of Related Patterns).
 
-### Generation
-Use Python with the `uuid7` library:
-```python
-import uuid7
-
-def generate_pattern_id():
-    return f"pat_{uuid7.uuid7().hex[:26]}"
-```
-
-Or use the provided script:
-```bash
-python3 scripts/generate_typeid.py
-```
-
-**Example IDs:**
-```
-pat_01kg5023vveprts2at71w6e29g
-pat_01kg502401ejststrxw4haba08
-```
-
-**Rules:**
-- IDs are immutable once assigned
-- IDs are globally unique across all patterns
-- IDs are the primary identifier for cross-references between patterns
-- The TypeID is the ONLY unique identifier — slugs are for human readability
+This eliminates content duplication, ensures data consistency, and keeps the authoring experience clean and focused.
 
 ---
 
-## 3. YAML Frontmatter
+## 3. The Definitive Frontmatter (v7.1)
 
-Every pattern MUST begin with YAML frontmatter enclosed in `---` delimiters.
-
-### Required Fields
+The frontmatter is organized into 7 functional groups. The only change from v7 is the addition of `vitality` and `vitality_reasoning` to the existing `commons_assessment` block in Group 3.
 
 ```yaml
 ---
-id: pat_{uuid7}                    # TypeID (required, immutable)
-page_url: https://commons-os.github.io/patterns/{slug}/
-github_url: https://github.com/commons-os/patterns/blob/main/_patterns/{slug}.md
-slug: {slug}                       # Must match filename without .md
-title: Pattern Title               # Human-readable title
-aliases: [Alias 1, Alias 2]        # Alternative names (can be empty [])
-version: 1.0                       # Semantic version
-created: YYYY-MM-DDTHH:MM:SSZ      # ISO 8601 timestamp
-modified: YYYY-MM-DDTHH:MM:SSZ     # ISO 8601 timestamp
+# ═══════════════════════════════════════════════════════════════════
+# GROUP 1: CORE IDENTITY
+# ═══════════════════════════════════════════════════════════════════
+id: pat_01h8x4e1gq7r9d1z2x3c4v5b6n
+slug: transparent-ledger
+title: "Transparent Ledger"
+aliases: ["Open Book Management"]
+summary: >-
+  A pattern for establishing collective trust by making operational data
+  and financial records accessible and auditable by all relevant stakeholders.
 
-classification:
-  universality: universal|domain   # universal = applies everywhere, domain = specific context
-  domain: governance|operations|finance|technology|culture|security|privacy|sovereignty|startup
-  category: [framework|practice|principle|tool|structure|process|anti-pattern]  # ARRAY - can have multiple
-  era: [pre-industrial|industrial|cognitive]
-  origin: [originator-name]        # Person or organization that created it
-  status: draft|review|published
-  commons_alignment: 1-5           # 1=low, 5=very high alignment with commons principles
-  commons_domain: [business, startup, security, urban, ecology, life]  # ARRAY - patterns can belong to multiple domains
+# ═══════════════════════════════════════════════════════════════════
+# GROUP 2: CONTEXTUAL TRANSLATION (The Navigator Engine)
+# ═══════════════════════════════════════════════════════════════════
+context_labels:
+  corporate: "Open Book Management"
+  government: "Public Account Auditing"
+  activist: "Radical Transparency"
+  tech: "Public Blockchain Ledger"
 
-# Pattern Relationships (use TypeIDs, can be empty [])
-generalizes_from: []               # This pattern is a more general form of...
-specializes_to: []                 # This pattern is specialized by...
-enables: []                        # This pattern enables...
-requires: []                       # This pattern requires...
-related: []                        # Related patterns
+# ═══════════════════════════════════════════════════════════════════
+# GROUP 3: ONTOLOGY & SEARCH OPTIMIZATION (The RAG Fuel)
+# ═══════════════════════════════════════════════════════════════════
+ontology:
+  domain: finance
+  cross_domains: [governance, technology]
+  search_hints:
+    primary_tension: "Information Asymmetry vs. Collective Trust"
+    vector_keywords: ["accountability", "ledger", "auditability", "commons", "transparency"]
+  commons_assessment:
+    stakeholder_architecture: 5
+    value_creation: 4
+    resilience: 5
+    ownership: 5
+    autonomy: 4
+    composability: 3
+    fractal_value: 5
+    vitality: 4.5
+    vitality_reasoning: >-
+      Scores highly because it directly enables feedback loops and
+      adaptation, which are the core mechanisms of any living system.
+      Weakness: potential for rigid implementation that stifles local
+      adaptation if governance is not sufficiently distributed.
+    overall_score: 4.4
 
-# Metadata
-contributors: [username1, username2]
-sources: [https://source1.com, https://source2.com]
+# ═══════════════════════════════════════════════════════════════════
+# GROUP 4: LIFECYCLE & CONFIDENCE
+# ═══════════════════════════════════════════════════════════════════
+lifecycle:
+  usage_stage: design
+  adoption_stage: growth
+  status: stable
+  version: 1.2
+  confidence: 3
+
+# ═══════════════════════════════════════════════════════════════════
+# GROUP 5: HARD RELATIONSHIPS (Human-Curated Graph)
+# ═══════════════════════════════════════════════════════════════════
+relationships:
+  generalizes_from: []
+  specializes_to: []
+  enables: []
+  requires: []
+  alternatives: []
+  complementary: []
+  tools: []
+
+# ═══════════════════════════════════════════════════════════════════
+# GROUP 6: GRAPH GARDEN (Machine-Written Graph)
+# ═══════════════════════════════════════════════════════════════════
+graph_garden:
+  last_pruned: 2026-02-17
+  entities: []
+  communities: []
+  inferred_links: []
+
+# ═══════════════════════════════════════════════════════════════════
+# GROUP 7: PROVENANCE
+# ═══════════════════════════════════════════════════════════════════
+contributors: ["higgerix", "cloudsters"]
+sources: []
 license: CC-BY-SA-4.0
-attribution: Commons OS distributed by cloudsters, https://cloudsters.net
-repository: https://github.com/commons-os/patterns
+attribution: "commons.engineering by cloudsters, https://cloudsters.net"
 ---
 ```
 
-### Field Descriptions
+### Vitality Scoring Guidance
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `id` | string | Yes | TypeID in format `pat_{uuid7}` — the unique identifier |
-| `page_url` | string | Yes | Public URL on GitHub Pages |
-| `github_url` | string | Yes | Direct link to file on GitHub |
-| `slug` | string | Yes | URL-friendly identifier, matches filename |
-| `title` | string | Yes | Human-readable pattern name |
-| `aliases` | array | Yes | Alternative names (can be empty) |
-| `version` | string | Yes | Semantic version (e.g., 1.0, 1.1) |
-| `created` | string | Yes | ISO 8601 creation timestamp |
-| `modified` | string | Yes | ISO 8601 last modified timestamp |
-| `classification.universality` | string | Yes | `universal` or `domain` |
-| `classification.domain` | string | Yes | Primary domain category |
-| `classification.category` | array | Yes | Pattern type(s) |
-| `classification.era` | array | Yes | Historical era(s) of applicability |
-| `classification.origin` | array | Yes | Creator(s) of the pattern |
-| `classification.status` | string | Yes | `draft`, `review`, or `published` |
-| `classification.commons_alignment` | integer | Yes | 1-5 score for commons alignment |
-| `classification.commons_domain` | array | Yes | High-level domain(s) - patterns can belong to multiple (e.g., `[business, startup]`) |
-| `generalizes_from` | array | Yes | TypeIDs of parent patterns |
-| `specializes_to` | array | Yes | TypeIDs of child patterns |
-| `enables` | array | Yes | TypeIDs of enabled patterns |
-| `requires` | array | Yes | TypeIDs of required patterns |
-| `related` | array | Yes | TypeIDs of related patterns |
-| `contributors` | array | Yes | GitHub usernames of contributors |
-| `sources` | array | Yes | URLs of reference sources (quote URLs with special characters) |
-| `license` | string | Yes | License identifier |
-| `attribution` | string | Yes | Attribution statement |
-| `repository` | string | Yes | Repository URL |
+The `vitality` field assesses the pattern's capacity to generate life, wholeness, and adaptive capacity in the systems that adopt it. Use the following rubric:
+
+| Score | Level | Meaning |
+|:---|:---|:---|
+| 4.5–5.0 | **Generative** | The pattern actively creates conditions for new life and adaptation to emerge. Systems using this pattern feel alive and evolving. |
+| 3.5–4.4 | **Sustaining** | The pattern maintains and renews existing vitality. Systems using it are healthy but not necessarily generating new capacity. |
+| 2.0–3.4 | **Functional** | The pattern works correctly but does not contribute to or may even dampen the system's aliveness. Risk of bureaucratic rigidity. |
+| 0.0–1.9 | **Extractive** | The pattern actively depletes vitality. It may solve a narrow problem but at the cost of the system's overall health. |
 
 ---
 
-## 4. Content Structure
+## 4. The Definitive Body Structure (v7.1)
 
-After the YAML frontmatter, the pattern content MUST follow this structure:
+The body is the author's canvas. It contains **8 author-written sections**. The remaining sections (Commons Alignment, Related Patterns, References) are generated from the frontmatter at build time.
 
 ```markdown
-### 1. Overview
+> A one-sentence summary of the pattern's core idea.
 
-[2-3 paragraphs describing what the pattern is, the problem it solves, and its origin]
+> [!NOTE] Confidence Rating: ★★★ (High)
+> This rating reflects our confidence that this pattern is a good and correct
+> solution to the stated problem.
 
-### 2. Core Principles
+---
 
-[Numbered list of the fundamental principles underlying the pattern]
+### Section 1: Context
 
-### 3. Key Practices
+*(100–200 words)*
 
-[Numbered list of specific practices or methods used to implement the pattern]
+Describes the situation or environment in which the problem arises. It should be a concise, narrative paragraph that helps the reader feel the living energy of the context — is this a system that is growing, stagnating, fragmenting, or decaying?
 
-### 4. Implementation
+---
 
-[Guidance on how to implement the pattern, including steps, considerations, and examples]
+### Section 2: Problem
 
-### 5. 7 Pillars Assessment
+*(100–200 words)*
 
-| Pillar | Score (1-5) | Rationale |
-|--------|-------------|-----------|
-| Purpose | X | [Why this score] |
-| Governance | X | [Why this score] |
-| Culture | X | [Why this score] |
-| Incentives | X | [Why this score] |
-| Knowledge | X | [Why this score] |
-| Technology | X | [Why this score] |
-| Resilience | X | [Why this score] |
-| **Overall** | **X.X** | **[Summary]** |
+> **The core conflict is [State the Primary Tension from the frontmatter].**
 
-### 6. When to Use
+After the bold problem statement, describe the **forces** at play. Forces are not abstract concepts; they are living tensions experienced by real people in real systems.
 
-[Bullet points or paragraphs describing ideal contexts for this pattern]
+---
 
-### 7. Anti-Patterns & Gotchas
+### Section 3: Solution
 
-[Common mistakes, misapplications, or things to watch out for]
+*(200–400 words)*
 
-### 8. References
+> **Therefore, [State the core instruction of the solution in one bold sentence].**
 
-[Numbered list of sources with links]
+After the bold solution statement, provide a detailed explanation of the mechanism. Include a diagram if it helps clarify the structure.
+
+---
+
+### Section 4: Implementation
+
+*(300–500 words)*
+
+Provide concrete, actionable steps for implementing the solution. This section should feel like a practical guide, not a theoretical treatise. Frame the steps as acts of cultivation — tending, protecting, and growing the living system.
+
+---
+
+### Section 5: Consequences
+
+*(200–300 words)*
+
+Describe the trade-offs and implications. What new capacities for life does it create? What forms of decay does it make possible if not tended carefully?
+
+---
+
+### Section 6: Known Uses
+
+*(200–300 words)*
+
+Provide at least two real-world examples of this pattern in action. Tell the stories of these living systems — don't just state facts.
+
+---
+
+### Section 7: Cognitive Era
+
+*(150–250 words)*
+
+How does this pattern change in the Cognitive Age? How does it interact with AI, autonomous agents, and distributed intelligence?
+
+---
+
+### Section 8: Vitality
+
+*(200–300 words)*
+
+This is the explicit diagnostic section. What does vitality look like in a system that uses this pattern? What are the signs of life? Conversely, what does decay look like? This section should provide a clear, actionable diagnostic for assessing the health of the pattern in practice.
 ```
 
 ---
 
-## 5. Validation Rules
+## 5. Workflow & Validation
 
-Before committing any pattern, verify:
-
-### Automated Checks (run `scripts/validate_entity.py`)
-- [ ] File is in `_patterns/` directory
-- [ ] Filename matches `{slug}.md` format (no numbers, lowercase, hyphens)
-- [ ] YAML frontmatter is valid and parseable
-- [ ] All required fields are present
-- [ ] `id` is in TypeID format (`pat_` prefix)
-- [ ] `slug` matches filename without `.md`
-- [ ] `commons_alignment` is between 1 and 5
-- [ ] All TypeID references in relationships exist in `graph.json`
-
-### Manual Checks
-- [ ] Content follows the 8-section structure
-- [ ] 7 Pillars Assessment table is complete with rationales
-- [ ] Sources are properly cited
-- [ ] No duplicate pattern (check by title, slug, and aliases)
-
----
-
-## 6. Workflow for Adding Patterns
-
-### Step 1: Generate TypeID
-```bash
-python3 scripts/generate_typeid.py
-# Output: pat_01kg5024abcdef123456789
-```
-
-### Step 2: Create Slug
-Choose a unique, descriptive slug:
-- Check existing patterns: `ls _patterns/`
-- Use pattern name + originator if needed for uniqueness
-
-### Step 3: Create File from Template
-```bash
-cp _templates/pattern.md _patterns/{slug}.md
-```
-
-### Step 4: Fill in Content
-- Replace all `{placeholders}` with actual values
-- Complete all 8 content sections
-- Fill in the 7 Pillars Assessment with rationales
-
-### Step 5: Validate
-```bash
-python3 scripts/validate_entity.py _patterns/{slug}.md
-```
-
-### Step 6: Commit
-```bash
-git add _patterns/{slug}.md
-git commit -m "Add pattern: {title}"
-git push
-```
-
----
-
-## 7. Commons Alignment Scoring Guide
-
-| Score | Label | Description |
-|-------|-------|-------------|
-| 5 | Very High | Fundamentally designed for collective value creation, stakeholder governance, long-term resilience |
-| 4 | High | Strongly supports commons principles, minor trade-offs possible |
-| 3 | Medium | Neutral tool, can be used for commons or extractive purposes depending on implementation |
-| 2 | Low | Tends toward extraction, short-term thinking, or concentrated control |
-| 1 | Very Low | Fundamentally extractive, undermines collective value creation |
-
----
-
-## 8. Domain Categories
-
-| Domain | Description | Examples |
-|--------|-------------|----------|
-| `governance` | Decision-making, authority, voting | Sociocracy, Steward Ownership |
-| `operations` | Processes, workflows, execution | Lean, Kanban |
-| `finance` | Funding, revenue, economics | Patient Capital, VC |
-| `technology` | Technical systems, infrastructure | Zero Trust, API Security |
-| `culture` | Values, norms, behaviors | Psychological Safety |
-| `security` | Protection, resilience, risk | Defense in Depth |
-| `privacy` | Data protection, consent | Data Minimization |
-| `sovereignty` | Independence, self-determination | Self-Sovereign Identity |
-| `startup` | Venture creation, scaling | Lean Startup, MVP |
-
----
-
-## 9. Retrieval & Indexing
-
-Patterns are stored as individual Markdown files, but retrieval is supported by generated indexes:
-
-### graph.json
-- Contains all pattern metadata and relationships
-- Rebuilt automatically on each push to main
-- Use for: finding patterns by TypeID, querying relationships
-
-### embeddings.json
-- Contains vector embeddings for semantic search
-- Rebuilt automatically when patterns change
-- Use for: "find patterns about X" queries
-
-**Note:** These indexes are derived from the Markdown files. The files are the source of truth.
-
----
-
-## 10. Version History
-
-| Version | Date | Changes |
-|---------|------|---------|
-| 1.3 | 2026-02-02 | Changed `commons_domain` and `category` to multi-value arrays per ADR-012 |
-| 1.0 | 2026-02-01 | Initial specification |
-| 1.1 | 2026-02-01 | Removed sequential numbers from filename format; slug-only naming |
-| 1.2 | 2026-02-02 | Renamed `tags` to `classification` to avoid Jekyll reserved keyword conflict |
-
----
-
-## 11. Questions?
-
-If anything in this specification is unclear, open an issue at:
-https://github.com/commons-os/patterns/issues
+1.  **Generate ID:** `python3 scripts/generate_typeid.py`
+2.  **Create File:** `cp _templates/pattern.md _patterns/{slug}.md`
+3.  **Fill Content:** Complete all YAML fields and the 8 body sections.
+4.  **Validate:** `python3 scripts/validate_entity.py _patterns/{slug}.md`
+5.  **Commit:** `git add _patterns/{slug}.md && git commit -m "Add pattern: {title}"`

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # Commons OS Pattern Library - Jekyll Configuration
 title: Commons OS Pattern Library
-description: Open-source knowledge graph of organizational patterns for a more equitable and sustainable world
+description: "The discipline and pattern library for Commons Engineers building resilient, living systems for the Cognitive Age."
 url: "https://commons-os.github.io"
 baseurl: "/patterns"
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -532,8 +532,8 @@
   
   <div class="footer-subscribe">
     <div class="footer-subscribe-container">
-      <h3>Design for resilience</h3>
-      <p>Get new patterns, case studies, and insights for Commons Engineers building value creation systems that last.</p>
+      <h3>Cultivate Living Systems</h3>
+      <p>Receive new patterns, vitality analysis, and insights for Cognitive Systems Builders who are stewarding the future.</p>
       <form class="footer-subscribe-form" id="substack-subscribe-form">
         <input type="email" name="email" id="substack-email" placeholder="Enter your email" required>
         <button type="submit" id="substack-submit-btn">Subscribe</button>

--- a/_templates/pattern.md
+++ b/_templates/pattern.md
@@ -1,100 +1,161 @@
----
-id: pat_{TYPEID}
-page_url: https://commons-os.github.io/patterns/{SLUG}/
-github_url: https://github.com/commons-os/patterns/blob/main/_patterns/{FILENAME}
-slug: {SLUG}
-title: {TITLE}
-aliases: [{ALIASES}]
-version: 1.0
-created: {CREATED_DATE}
-modified: {MODIFIED_DATE}
-tags:
-  universality: {universal|domain}
-  domain: {governance|operations|finance|technology|culture|security|privacy|sovereignty|startup}
-  category: [{framework|practice|principle|tool|structure|process|anti-pattern}]
-  era: [{pre-industrial|industrial|cognitive}]
-  origin: [{ORIGINATOR}]
-  status: draft
-  commons_alignment: {1-5}
-commons_domain: {business|security|startup|urban|ecology|life}
-generalizes_from: []
-specializes_to: []
-enables: []
-requires: []
-related: []
-contributors: [{CONTRIBUTORS}]
-sources: [{SOURCES}]
+--- 
+# ═══════════════════════════════════════════════════════════════════
+# GROUP 1: CORE IDENTITY
+# ═══════════════════════════════════════════════════════════════════
+id: pat_{TYPEID}                       # REQUIRED. UUID7-based TypeID.
+slug: {SLUG}                          # REQUIRED. Human-readable URL slug.
+title: "{TITLE}"                       # REQUIRED. The official title of the pattern.
+aliases: []                            # OPTIONAL. Alternative names for search expansion.
+summary: >-                            # REQUIRED. For cards and search snippets (1-2 sentences).
+  {A one-sentence summary of the pattern's core idea.}
+
+# ═══════════════════════════════════════════════════════════════════
+# GROUP 2: CONTEXTUAL TRANSLATION (The Navigator Engine)
+# ═══════════════════════════════════════════════════════════════════
+context_labels:
+  corporate: "{Corporate-friendly name}"
+  government: "{Government-friendly name}"
+  activist: "{Activist-friendly name}"
+  tech: "{Tech-friendly name}"
+
+# ═══════════════════════════════════════════════════════════════════
+# GROUP 3: ONTOLOGY & SEARCH OPTIMIZATION (The RAG Fuel)
+# ═══════════════════════════════════════════════════════════════════
+ontology:
+  domain: {finance|governance|...}     # The primary domain this pattern belongs to.
+  cross_domains: []                    # Other domains with strong connections.
+  search_hints:
+    primary_tension: "{Tension A} vs. {Tension B}"
+    vector_keywords: []
+  commons_assessment:
+    stakeholder_architecture: 3        # 1-5. Who has voice and power?
+    value_creation: 3                  # 1-5. Does it create shared value?
+    resilience: 3                      # 1-5. Can it adapt and survive shocks?
+    ownership: 3                       # 1-5. Is ownership distributed?
+    autonomy: 3                        # 1-5. Does it enable self-governance?
+    composability: 3                   # 1-5. Can it be combined with other patterns?
+    fractal_value: 3                   # 1-5. Does value creation repeat at every scale?
+    vitality: 3.0                      # NEW v7.1 — 0.0-5.0. Does it generate life?
+    vitality_reasoning: >-             # NEW v7.1 — Concise explanation (1-3 sentences).
+      {Reasoning for vitality score, including strengths and weaknesses.}
+    overall_score: 3.0                 # Calculated average (now includes vitality).
+
+# ═══════════════════════════════════════════════════════════════════
+# GROUP 4: LIFECYCLE & CONFIDENCE
+# ═══════════════════════════════════════════════════════════════════
+lifecycle:
+  usage_stage: design                  # {ideation|design|implementation|operation}
+  adoption_stage: emerging             # {emerging|growth|mature}
+  status: draft                        # {draft|revised|stable|deprecated}
+  version: 1.0
+  confidence: 2                        # {3|2|1} → ★★★|★★☆|★☆☆
+
+# ═══════════════════════════════════════════════════════════════════
+# GROUP 5: HARD RELATIONSHIPS (Human-Curated Graph)
+# ═══════════════════════════════════════════════════════════════════
+relationships:
+  generalizes_from: []
+  specializes_to: []
+  enables: []
+  requires: []
+  alternatives: []
+  complementary: []
+  tools: []
+
+# ═══════════════════════════════════════════════════════════════════
+# GROUP 6: GRAPH GARDEN (Machine-Written Graph)
+# ═══════════════════════════════════════════════════════════════════
+graph_garden:
+  last_pruned: {YYYY-MM-DD}
+  entities: []
+  communities: []
+  inferred_links: []
+
+# ═══════════════════════════════════════════════════════════════════
+# GROUP 7: PROVENANCE
+# ═══════════════════════════════════════════════════════════════════
+contributors: ["higgerix", "cloudsters"]
+sources: []
 license: CC-BY-SA-4.0
-attribution: Commons OS distributed by cloudsters, https://cloudsters.net
-repository: https://github.com/commons-os/patterns
+attribution: "commons.engineering by cloudsters, https://cloudsters.net"
 ---
 
-### 1. Overview
+> {A one-sentence summary of the pattern's core idea.}
 
-{Describe what the pattern is, the problem it solves, and its origin. 2-3 paragraphs.}
+> [!NOTE] Confidence Rating: ★★☆ (Medium)
+> This rating reflects our confidence that this pattern is a good and correct
+> solution to the stated problem. High (★★★) means it is a well-established,
+> proven pattern. Medium (★★☆) means it is a promising but not yet fully proven
+> solution. Low (★☆☆) means it is an emerging or experimental idea.
 
-### 2. Core Principles
+---
 
-{List the fundamental principles underlying the pattern.}
+### Section 1: Context
 
-1. **Principle 1**: {Description}
-2. **Principle 2**: {Description}
-3. **Principle 3**: {Description}
+*(100–200 words)*
 
-### 3. Key Practices
+{Describe the situation or environment in which the problem arises. Describe not just the structural situation but the living energy of the context — is this a system that is growing, stagnating, fragmenting, or decaying?}
 
-{List specific practices or methods used to implement the pattern.}
+---
 
-1. **Practice 1**: {Description}
-2. **Practice 2**: {Description}
-3. **Practice 3**: {Description}
+### Section 2: Problem
 
-### 4. Implementation
+*(100–200 words)*
 
-{Provide guidance on how to implement the pattern, including steps, considerations, and examples.}
+> **The core conflict is {State the Primary Tension from the frontmatter}.**
 
-**Steps:**
-1. {Step 1}
-2. {Step 2}
-3. {Step 3}
+{Describe the **forces** at play — the conflicting needs, constraints, and goals that make the problem difficult. What does it feel like to be caught between these forces?}
 
-**Considerations:**
-- {Consideration 1}
-- {Consideration 2}
+-   **Force 1:** {Description of the first conflicting need or constraint.}
+-   **Force 2:** {Description of the second conflicting need or constraint.}
+-   **Force 3:** {Description of the third conflicting need or constraint.}
 
-**Example:**
-{Provide a real-world example of this pattern in action.}
+---
 
-### 5. 7 Pillars Assessment
+### Section 3: Solution
 
-| Pillar | Score (1-5) | Rationale |
-|--------|-------------|-----------|
-| Purpose | {X} | {Why this score} |
-| Governance | {X} | {Why this score} |
-| Culture | {X} | {Why this score} |
-| Incentives | {X} | {Why this score} |
-| Knowledge | {X} | {Why this score} |
-| Technology | {X} | {Why this score} |
-| Resilience | {X} | {Why this score} |
-| **Overall** | **{X.X}** | **{Summary of commons alignment}** |
+*(200–400 words)*
 
-### 6. When to Use
+> **Therefore, {State the core instruction of the solution in one bold sentence}.**
 
-{Describe ideal contexts for this pattern.}
+{Provide a detailed explanation. Describe the structure, participants, and collaborations involved. Explain the mechanism — how and why the solution resolves the forces described in Section 2. Include a diagram if it helps clarify the structure.}
 
-- {Context 1}
-- {Context 2}
-- {Context 3}
+---
 
-### 7. Anti-Patterns & Gotchas
+### Section 4: Implementation
 
-{List common mistakes, misapplications, or things to watch out for.}
+*(300–500 words)*
 
-- **{Anti-pattern 1}**: {Description}
-- **{Anti-pattern 2}**: {Description}
-- **{Anti-pattern 3}**: {Description}
+{Provide concrete, actionable steps for implementing the solution. This section should feel like a practical guide, not a theoretical treatise. Use code snippets, configuration examples, checklists, or step-by-step instructions. Frame the steps as acts of cultivation — tending, protecting, and growing the living system.}
 
-### 8. References
+---
 
-[1] {Author}. ({Year}). *{Title}*. {Publisher/URL}. Retrieved from {URL}
-[2] {Author}. ({Year}). *{Title}*. {Publisher/URL}. Retrieved from {URL}
+### Section 5: Consequences
+
+*(200–300 words)*
+
+{Describe the trade-offs and implications of implementing this pattern. What new capacities for life does it create? What forms of decay does it make possible if not tended carefully? What are the known failure modes?}
+
+---
+
+### Section 6: Known Uses
+
+*(200–300 words)*
+
+{Provide at least two real-world examples of this pattern in action. Tell the stories of these living systems — don't just state facts. Link to the organizations or projects if possible.}
+
+---
+
+### Section 7: Cognitive Era
+
+*(150–250 words)*
+
+{How does this pattern change in the Cognitive Age? How does it interact with AI, autonomous agents, and distributed intelligence? Does it enable new forms of life and partnership? Does it create new vulnerabilities?}
+
+---
+
+### Section 8: Vitality
+
+*(200–300 words)*
+
+{This is the explicit diagnostic section. What does vitality look like in a system that uses this pattern? What are the signs of life? Conversely, what does decay look like? What are the warning signs that the pattern is being implemented in a way that stifles life? This section should provide a clear, actionable diagnostic for assessing the health of the pattern in practice.}

--- a/business/index.html
+++ b/business/index.html
@@ -152,6 +152,7 @@ title: Business Patterns - Commons OS
 <div class="domain-header">
   <div class="icon-circle">🏢</div>
   <h1>Business Patterns</h1>
+  <p class="subtitle">Tools for building organizations that thrive on change.</p>
   <p>Organizations, enterprises, cooperatives, and ventures</p>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
----
+--- 
 layout: default
-title: Pattern Engine - Commons OS
+title: Commons Engineering - A Discipline for the Cognitive Age
 ---
 
 <style>
@@ -126,7 +126,7 @@ title: Pattern Engine - Commons OS
   }
   
   .section h2::after {
-    content: '';
+    content: 
     display: block;
     width: 60px;
     height: 4px;
@@ -303,27 +303,27 @@ title: Pattern Engine - Commons OS
 </style>
 
 <div class="hero">
-  <div class="icon">⬡</div>
-  <h1>Pattern Engine</h1>
-  <p class="tagline">The collective intelligence of proven solutions. {{ site.patterns.size }}+ patterns for building resilient organizations, cities, ecologies, and lives.</p>
+  <div class="icon">🌿</div>
+  <h1>From Invisible Expert to Resilient Steward</h1>
+  <p class="tagline">Commons Engineering is the discipline for building living, adaptive systems in the Cognitive Age. This is the home of its core tool: a living library of {{ site.patterns.size }}+ patterns for making your systems thinking visible, influential, and effective.</p>
   <div class="cta-buttons">
-    <a href="{{ site.baseurl }}/business/" class="cta-primary">Browse Business Patterns</a>
-    <a href="{{ site.baseurl }}/suggest/" class="cta-secondary">Suggest a Pattern</a>
+    <a href="{{ site.baseurl }}/business/" class="cta-primary">Explore Patterns</a>
+    <a href="{{ site.baseurl }}/PATTERN_SPEC/" class="cta-secondary">Learn the Discipline</a>
   </div>
 </div>
 
 <div class="stats-bar">
   <div class="stat">
     <div class="circle">{{ site.patterns.size }}</div>
-    <div class="label">Patterns</div>
+    <div class="label">Living Patterns</div>
   </div>
   <div class="stat">
     <div class="circle">3.5k</div>
     <div class="label">Relationships</div>
   </div>
   <div class="stat">
-    <div class="circle">5</div>
-    <div class="label">Universality Levels</div>
+    <div class="circle">8</div>
+    <div class="label">Vitality Dimensions</div>
   </div>
   <div class="stat">
     <div class="circle">4</div>
@@ -333,13 +333,13 @@ title: Pattern Engine - Commons OS
 
 <div class="intro-box">
   <p>
-    <strong>Patterns are proven solutions to recurring problems.</strong> They're not prescriptions — they're starting points. Each pattern captures the essence of what works, distilled from real-world experience. Your job as a Commons Engineer is to adapt them to your context.
+    You see the systems failing. You know how to fix them. But you feel invisible. As AI automates expertise, you fear becoming irrelevant—a sidelined witness to preventable harm. <strong>Commons Engineering is the path to turn your invisible knowledge into recognized leadership.</strong>
   </p>
 </div>
 
 <div class="section">
   <h2>Commons Domains</h2>
-  <p class="subtitle">Choose your domain. Find patterns that work.</p>
+  <p class="subtitle">Find proven patterns for building living systems in your domain.</p>
   
   <div class="domains-grid">
     <a href="{{ site.baseurl }}/business/" class="domain-card business">
@@ -368,49 +368,22 @@ title: Pattern Engine - Commons OS
   </div>
 </div>
 
-<div class="levels-section">
-  <h3>📊 Universality Levels</h3>
-  <p style="margin-bottom: 20px; color: var(--text-muted);">Patterns are organized by how broadly they apply:</p>
-  <div class="levels-grid">
-    <div class="level-item">
-      <div class="level-name">Universal</div>
-      <div class="level-desc">Apply everywhere</div>
-    </div>
-    <div class="level-item">
-      <div class="level-name">Domain</div>
-      <div class="level-desc">Specific to a field</div>
-    </div>
-    <div class="level-item">
-      <div class="level-name">Context</div>
-      <div class="level-desc">Situation-dependent</div>
-    </div>
-    <div class="level-item">
-      <div class="level-name">Method</div>
-      <div class="level-desc">How to do it</div>
-    </div>
-    <div class="level-item">
-      <div class="level-name">Implementation</div>
-      <div class="level-desc">Concrete tools</div>
-    </div>
-  </div>
-</div>
-
 <div class="section">
-  <h2>How to Use Patterns</h2>
-  <p class="subtitle">Patterns are building blocks, not blueprints.</p>
+  <h2>Your Path to Recognized Leadership</h2>
+  <p class="subtitle">Patterns are the tools. The journey is yours. This is how you start.</p>
   
   <ol style="font-size: 1.1em; line-height: 2;">
-    <li><strong>Understand the problem</strong> — What challenge are you facing?</li>
-    <li><strong>Search for patterns</strong> — Use the search bar or browse by domain</li>
-    <li><strong>Study the pattern</strong> — Understand the forces, context, and trade-offs</li>
-    <li><strong>Adapt to your context</strong> — No pattern applies exactly as written</li>
-    <li><strong>Combine patterns</strong> — Real solutions often combine multiple patterns</li>
-    <li><strong>Learn from Lighthouses</strong> — See how others have applied the pattern</li>
+    <li><strong>Make Your Value Visible</strong> — Use patterns to articulate your insights and make your expertise legible.</li>
+    <li><strong>Define Real Ownership</strong> — Apply governance patterns to clarify who owns what, so initiatives don’t die in the gaps.</li>
+    <li><strong>Design Decision Loops</strong> — Build resilient systems that adapt under uncertainty.</li>
+    <li><strong>Align Incentives Early</strong> — Use patterns to surface and redesign the hidden rules of the game.</li>
+    <li><strong>Build Self-Correcting Systems</strong> — Install feedback signals so your systems learn and evolve.</li>
+    <li><strong>Become a Steward</strong> — Evolve from a silent observer to a recognized leader who guides living systems.</li>
   </ol>
 </div>
 
 <div class="cta-section">
-  <h3>Can't Find What You Need?</h3>
-  <p>Help us grow the pattern library by suggesting patterns you've seen work.</p>
+  <h3>Become a Co-Creator</h3>
+  <p>This is a living library, tended by a community of peers. Help us cultivate it by suggesting new patterns or improving existing ones.</p>
   <a href="{{ site.baseurl }}/suggest/">Suggest a Pattern</a>
 </div>

--- a/index.html
+++ b/index.html
@@ -338,6 +338,18 @@ title: Commons Engineering - A Discipline for the Cognitive Age
 </div>
 
 <div class="section">
+  <h2>Curated Collections</h2>
+  <p class="subtitle">Guided paths through the pattern library. Start here.</p>
+  <div class="domains-grid" style="margin-bottom: 60px;">
+    <a href="{{ site.baseurl }}/commons-blueprint/" class="domain-card business">
+      <div class="icon-circle">🗺️</div>
+      <h3>The Commons Blueprint</h3>
+      <span class="badge active">41 Patterns</span>
+    </a>
+  </div>
+</div>
+
+<div class="section">
   <h2>Commons Domains</h2>
   <p class="subtitle">Find proven patterns for building living systems in your domain.</p>
   


### PR DESCRIPTION
## Summary

This PR enriches all main pages of the Commons OS site with the language of vitality and the Cognitive Systems Builder ICP.

### Changes

| File | Change |
|---|---|
| `index.html` | Rewrite headline ('From Invisible Expert to Resilient Steward'), intro box speaks to ICP's deep fear, CTAs reframed |
| `_config.yml` | Site description updated to 'living systems for the Cognitive Age' |
| `_layouts/default.html` | Newsletter section: 'Cultivate Living Systems' + ICP-resonant description |
| `_templates/pattern.md` | Replaced with v7.1 template (vitality YAML fields + Section 8) |
| `PATTERN_SPEC.md` | Full rewrite to match v7.1 structure with vitality scoring guidance |
| `ARCHITECTURE.md` | Reframed as 'Architecture of a Living Library', authorship corrected |
| `AGENT_BOOT.md` | Added mission framing |
| `business/index.html` | Added ICP-resonant subtitle |

### Design Principles

- **commons.engineering** voice: 'We' = the discipline, not cloudsters
- cloudsters appears only in footer attribution
- No CEN|F branding on this site
- ICP language woven naturally, not as marketing copy